### PR TITLE
updated FabOS title text

### DIFF
--- a/content/project/fab_os.md
+++ b/content/project/fab_os.md
@@ -1,5 +1,5 @@
 ---
-title: "FabOS - An Open, Distributed, Real-Time Capable, and Secure Operating System for Production"
+title: "FabOS"
 date: 2020-03-11T14:40:39-04:00
 logo: "/images/research/fabos.png"
 tags: ["Standard", "Industry 4.0"]


### PR DESCRIPTION
Removed the long text from FabOS title so on the main page in the project list only "FabOS" is shown.

Signed-off-by: Marco <marco.jahn@eclipse-foundation.org>