### PR TITLE
Fix IE Images are not aligned well on IE #37

### DIFF
--- a/layouts/project/summary.html
+++ b/layouts/project/summary.html
@@ -2,7 +2,7 @@
   <div class="padding-20 text-center background-white flex-grow">
     <h2 class="h4">
       <a href="{{ .Permalink }}">
-  	    <span class="vertical-align margin-bottom-20" style="height:75px">
+  	    <span class="vertical-align flex-column margin-bottom-20" style="height:75px">
           {{ if .Params.logo }}
 	      <img class="img img-responsive margin-auto padding-15" src="{{ .Params.logo | relURL }}" alt="{{ .Title }} logo" height="75"/>
           {{ else }}


### PR DESCRIPTION
Fix #37 

After Fixing:
![image](https://user-images.githubusercontent.com/39588094/100618489-e96dfb80-32e9-11eb-9bb8-be65af4928b0.png)
![image](https://user-images.githubusercontent.com/39588094/100618526-f38ffa00-32e9-11eb-91e4-85153ac90881.png)

A reference for this fix: https://stackoverflow.com/questions/42302289/workaround-for-ie-10-11-flex-child-overflow-alignment

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>